### PR TITLE
Fix the issue which generates a deprecated warning on PHP 8.1 - PHP D…

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -66,7 +66,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', null, $user['user_id']),
+            'id'       => str_replace('https://www.paypal.com/webapps/auth/identity/user/', '', $user['user_id']),
             'nickname' => null,
             'name'     => $user['name'] ?? null,
             'email'    => collect($user['emails'] ?? [])->firstWhere('primary')['value'] ?? null,


### PR DESCRIPTION
![Screenshot 2024-02-06 at 14 41 52](https://github.com/SocialiteProviders/PayPal/assets/42751239/7b710f81-4726-4a92-8822-80b8d484ba67)

…eprecated:  str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated