### PR TITLE
Add Sandbox Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 'paypal' => [    
   'client_id' => env('PAYPAL_CLIENT_ID'),  
   'client_secret' => env('PAYPAL_CLIENT_SECRET'),  
-  'redirect' => env('PAYPAL_REDIRECT_URI') 
+  'redirect' => env('PAYPAL_REDIRECT_URI'),
+  'sandbox' => false,
 ],
 ```
+
+#### Sandbox
+The sandbox boolean is used to target either production (false - default), or PayPal sandbox (true) endpoints
 
 ### Add provider event listener
 


### PR DESCRIPTION
Adds an optional "sandbox" option for  the services.paypal array

This allows to toggle which endpoint is used (either production or sandbox).

Haven't fully tested with every permutation, but should function smoothly.